### PR TITLE
Simplify dependency declaration to JUnit Jupiter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,17 +57,10 @@
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
+      <artifactId>junit-jupiter</artifactId>
       <version>5.6.0</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <version>5.6.0</version>
-      <scope>test</scope>
-    </dependency>
-
 
   </dependencies>
 </project>


### PR DESCRIPTION
Make use of the "Jupiter Aggregator" module that pulls in all required Jupiter modules:

- junit-jupiter-api
- junit-jupiter-params
- junit-jupiter-engine

See also the "Maven Starter for JUnit Jupiter" at https://github.com/junit-team/junit5-samples/blob/r5.6.0/junit5-jupiter-starter-maven/pom.xml