### PR TITLE
Fix warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   </properties>
 
   <build>
-    <finalName>${artifactId}</finalName>
+    <finalName>${project.artifactId}</finalName>
 
     <plugins>
       <plugin>


### PR DESCRIPTION
Either you use this to remove the WARNING during the Maven build or you simply remove the `<finalName>..</finalName>` at all...